### PR TITLE
Negative extensions

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -214,7 +214,7 @@ fn alpha_beta<const IS_PV: bool>(
 
     // TODO: Killers should probably be reset here
     // td.stack[td.ply + 1].killers = [Move::NULL; 2];
-    if td.ply < MAX_SEARCH_DEPTH {
+    if td.ply < MAX_SEARCH_DEPTH - 1 {
         td.stack[td.ply + 1].singular = Move::NULL
     }
     if !is_root {

--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -366,6 +366,8 @@ fn alpha_beta<const IS_PV: bool>(
                 } else {
                     1
                 }
+            } else if tt_score >= beta {
+                -2 + i32::from(IS_PV)
             } else {
                 0
             }


### PR DESCRIPTION
Elo   | 10.75 +- 6.19 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6238 W: 1706 L: 1513 D: 3019
Penta | [30, 650, 1581, 813, 45]
http://localhost:8000/test/64/