### PR TITLE
Smp (#112)

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -4,7 +4,6 @@ use crate::{
     board::fen::build_board,
     engine::transposition::{TranspositionTable, TARGET_TABLE_SIZE_MB},
     search::{search::search, thread::ThreadData, SearchType},
-    types::pieces::Color,
 };
 
 pub fn bench() {
@@ -12,7 +11,7 @@ pub fn bench() {
 
     let transpos_table = TranspositionTable::new(TARGET_TABLE_SIZE_MB);
     let halt = AtomicBool::new(false);
-    let mut thread = ThreadData::new(Color::White, &halt, Vec::new());
+    let mut thread = ThreadData::new(&halt, Vec::new());
     thread.max_depth = 14;
     thread.search_type = SearchType::Depth;
 

--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -10,8 +10,8 @@ use std::{
 use crate::{
     board::board::Board,
     engine::{transposition::TranspositionTable, uci::parse_time},
+    moves::moves::Move,
     search::search::{CHECKMATE, NEAR_CHECKMATE},
-    types::pieces::Color,
 };
 
 use super::{
@@ -28,20 +28,21 @@ pub(crate) struct ThreadData<'a> {
     pub iter_max_depth: i32,
     /// Max depth reached by a pv node
     pub sel_depth: i32,
+    pub best_move: Move,
 
     pub nodes_searched: u64,
+    pub global_nodes: Arc<AtomicU64>,
     pub stack: SearchStack,
     pub history: HistoryTable,
     pub hash_history: Vec<u64>,
 
-    pub root_color: Color,
     pub game_time: GameTime,
     pub search_type: SearchType,
     pub halt: &'a AtomicBool,
 }
 
 impl<'a> ThreadData<'a> {
-    pub(crate) fn new(root_color: Color, halt: &'a AtomicBool, hash_history: Vec<u64>) -> Self {
+    pub(crate) fn new(halt: &'a AtomicBool, hash_history: Vec<u64>) -> Self {
         Self {
             ply: 0,
             max_depth: MAX_SEARCH_DEPTH,
@@ -49,8 +50,9 @@ impl<'a> ThreadData<'a> {
             nodes_searched: 0,
             stack: SearchStack::default(),
             sel_depth: 0,
+            best_move: Move::NULL,
+            global_nodes: Arc::new(AtomicU64::new(0)),
             history: HistoryTable::default(),
-            root_color,
             game_time: GameTime::default(),
             halt,
             search_type: SearchType::default(),
@@ -59,14 +61,14 @@ impl<'a> ThreadData<'a> {
     }
 
     pub(super) fn print_search_stats(&self, eval: i32, pv: &PV, tt: &TranspositionTable) {
+        let nodes = self.global_nodes.load(Ordering::Relaxed);
         print!(
             "info time {} depth {} seldepth {} nodes {} nps {} score ",
             self.game_time.search_start.elapsed().as_millis(),
             self.iter_max_depth,
             self.sel_depth,
-            self.nodes_searched,
-            (self.nodes_searched as f64 / self.game_time.search_start.elapsed().as_secs_f64())
-                as i64,
+            nodes,
+            (nodes as f64 / self.game_time.search_start.elapsed().as_secs_f64()) as i64,
         );
 
         let score = eval;
@@ -89,7 +91,7 @@ impl<'a> ThreadData<'a> {
         println!();
     }
 
-    pub(crate) fn is_repetition(&self, board: &Board) -> bool {
+    pub(super) fn is_repetition(&self, board: &Board) -> bool {
         if self.hash_history.len() < 6 {
             return false;
         }
@@ -107,15 +109,18 @@ impl<'a> ThreadData<'a> {
 
 pub struct ThreadPool<'a> {
     pub main_thread: ThreadData<'a>,
+    pub workers: Vec<ThreadData<'a>>,
     pub halt: &'a AtomicBool,
     pub searching: AtomicBool,
     pub total_nodes: Arc<AtomicU64>,
 }
 
 impl<'a> ThreadPool<'a> {
-    pub fn new(board: &Board, halt: &'a AtomicBool, hash_history: Vec<u64>) -> Self {
+    pub fn new(halt: &'a AtomicBool, hash_history: Vec<u64>) -> Self {
+        let workers = vec![ThreadData::new(halt, hash_history.clone())];
         Self {
-            main_thread: ThreadData::new(board.to_move, halt, hash_history),
+            main_thread: ThreadData::new(halt, hash_history),
+            workers,
             halt,
             searching: AtomicBool::new(false),
             total_nodes: Arc::new(AtomicU64::new(0)),
@@ -125,8 +130,22 @@ impl<'a> ThreadPool<'a> {
     pub fn reset(&mut self) {
         self.main_thread.history = HistoryTable::default();
         self.main_thread.nodes_searched = 0;
+        for t in self.workers.iter_mut() {
+            t.history = HistoryTable::default();
+            t.nodes_searched = 0;
+        }
         self.halt.store(false, Ordering::Relaxed);
         self.searching.store(false, Ordering::Relaxed);
+        self.total_nodes.store(0, Ordering::Relaxed);
+    }
+
+    /// This thread creates a number of workers equal to threads - 1. If 4 threads are requested,
+    /// the main thread counts as one and then the remaining three are placed in the worker queue.
+    pub fn add_workers(&mut self, threads: usize, hash_history: Vec<u64>) {
+        self.workers.clear();
+        for _ in 0..threads - 1 {
+            self.workers.push(ThreadData::new(self.halt, hash_history.clone()));
+        }
     }
 
     pub fn handle_go(
@@ -138,26 +157,58 @@ impl<'a> ThreadPool<'a> {
         hash_history: Vec<u64>,
         tt: &TranspositionTable,
     ) {
-        self.halt.store(false, Ordering::SeqCst);
-        self.main_thread.hash_history = hash_history;
+        self.halt.store(false, Ordering::Relaxed);
+        self.total_nodes.store(0, Ordering::Relaxed);
+        self.main_thread.global_nodes = self.total_nodes.clone();
+        self.main_thread.hash_history = hash_history.clone();
+        for t in self.workers.iter_mut() {
+            t.hash_history = hash_history.clone();
+            t.global_nodes = self.total_nodes.clone();
+        }
 
         if buffer.contains(&"depth") {
             let mut iter = buffer.iter().skip(2);
             let depth = iter.next().unwrap().parse::<i32>().unwrap();
             self.main_thread.max_depth = depth;
+            for t in self.workers.iter_mut() {
+                t.max_depth = depth;
+            }
             self.main_thread.search_type = SearchType::Depth;
+            for t in self.workers.iter_mut() {
+                t.search_type = SearchType::Depth;
+            }
         } else if buffer.contains(&"wtime") {
             self.main_thread.search_type = SearchType::Time;
-            self.main_thread.game_time = parse_time(buffer);
-            self.main_thread.game_time.recommended_time(board.to_move);
+            for t in self.workers.iter_mut() {
+                t.search_type = SearchType::Time;
+            }
+
+            let mut clock = parse_time(buffer);
+            clock.recommended_time(board.to_move);
+
+            self.main_thread.game_time = clock;
+            for t in self.workers.iter_mut() {
+                t.game_time = clock;
+            }
         } else {
             self.main_thread.search_type = SearchType::Infinite;
+            for t in self.workers.iter_mut() {
+                t.search_type = SearchType::Infinite;
+            }
         }
 
         thread::scope(|s| {
-            s.spawn(move || {
-                println!("bestmove {}", search(&mut self.main_thread, true, *board, tt).to_san());
+            s.spawn(|| {
+                search(&mut self.main_thread, true, *board, tt);
+                self.halt.store(true, Ordering::Relaxed);
+                println!("bestmove {}", self.main_thread.best_move.to_san());
             });
+            for t in &mut self.workers {
+                s.spawn(|| {
+                    search(t, false, *board, tt);
+                });
+            }
+
             let mut s = String::new();
             io::stdin().read_line(&mut s).unwrap();
             match s.as_str().trim() {

--- a/src/spsa.rs
+++ b/src/spsa.rs
@@ -36,7 +36,7 @@ pub fn parse_param(a: &[&str]) {
     let [_, _, name, _, value] = a[..5] else { unimplemented!() };
     let name = name.to_uppercase();
     let param = ARR.iter().find(|&x| x.name == name).unwrap();
-    param.value.store(value.parse().unwrap(), Ordering::SeqCst);
+    param.value.store(value.parse().unwrap(), Ordering::Relaxed);
     (param.callback)();
 }
 


### PR DESCRIPTION
* first attempt - not any faster than single thread bench: 4580743

* actually it might work... bench: 4580743

* increase max threads printed in info message bench: 4580743

* dont update nodes in the first few depths to avoid contention bench: 4580743

* skip quiet tt move in qs
Elo   | 3.02 +- 4.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.06 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10022 W: 2668 L: 2581 D: 4773
Penta | [63, 1066, 2672, 1141, 69]
bruh good enough...
bench: 4732524

* zero window reduced depth search should always be a cutnode bench: 4244648

* see what happens when it just always has two threads bench: 4244648

* actually modify thread number with uci options bench: 4244648

---------