### PR TITLE
dont update history for trivial quiet moves

### DIFF
--- a/src/search/history_table.rs
+++ b/src/search/history_table.rs
@@ -74,8 +74,10 @@ impl HistoryTable {
             if stack.prev_move(ply - 1) != Move::NULL {
                 self.set_counter(stack.prev_move(ply - 1), best_move);
             }
-            self.update_quiet_history(best_move, true, depth);
-            self.update_cont_hist(best_move, stack, ply, true, depth);
+            if depth > 3 || quiets_tried.len() > 1 {
+                self.update_quiet_history(best_move, true, depth);
+                self.update_cont_hist(best_move, stack, ply, true, depth);
+            }
             // Only penalize quiets if best_move was quiet
             for m in quiets_tried {
                 if *m == best_move {


### PR DESCRIPTION
bench: 6580944
Elo   | 7.63 +- 5.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9384 W: 2599 L: 2393 D: 4392
Penta | [63, 1033, 2301, 1225, 70]
https://chess.drpowell.org/test/154/