### PR TITLE
simplify out check extensions

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -157,9 +157,11 @@ fn negamax<const IS_PV: bool>(
         return 0;
     }
 
-    if depth <= 0 {
+    if depth <= 0 && !in_check {
         return quiescence::<IS_PV>(alpha, beta, pv, td, tt, board);
     }
+
+    depth = depth.max(0);
 
     // Don't prune at root to ensure we have a best move
     if !is_root {
@@ -178,9 +180,6 @@ fn negamax<const IS_PV: bool>(
         if alpha >= beta {
             return alpha;
         }
-
-        // Extend depth by one if we are in check
-        depth += i32::from(in_check);
     }
 
     let mut tt_move = Move::NULL;


### PR DESCRIPTION
bench 5199914

Elo   | 2.26 +- 4.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 10128 W: 2449 L: 2383 D: 5296
Penta | [27, 1153, 2633, 1229, 22]
https://chess.drpowell.org/test/215/

Elo   | 4.32 +- 5.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 6682 W: 1692 L: 1609 D: 3381
Penta | [36, 761, 1674, 824, 46]
https://chess.drpowell.org/test/214/
