### PR TITLE
cutnode negative extensions

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -560,6 +560,8 @@ fn extension<const IS_PV: bool>(
         }
     } else if entry.search_score() >= beta {
         -2 + i32::from(IS_PV)
+    } else if cut_node {
+        -2
     } else if entry.search_score() <= alpha {
         -1
     } else {


### PR DESCRIPTION
bench: 5735828

Elo   | 2.39 +- 2.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33832 W: 8435 L: 8202 D: 17195
Penta | [36, 3687, 9253, 3888, 52]
https://chess.drpowell.org/test/346/