### PR TITLE
Resolve engine crashing when negative time values are received

### DIFF
--- a/src/search/game_time.rs
+++ b/src/search/game_time.rs
@@ -34,7 +34,7 @@ impl Clock {
 
     /// Calculates a recommended amount of time to spend on a given search.
     pub fn recommended_time(&mut self, side: Color) {
-        let clock = self.time_remaining[side] - GUI_DELAY;
+        let clock = (self.time_remaining[side].saturating_sub(GUI_DELAY)).max(GUI_DELAY);
         let time = clock / 20 + self.time_inc[side] * 3 / 4;
         self.rec_time = time.mul_f64(TIME_FRACTION);
         self.max_time = (time * 2).min(self.time_remaining[side]);

--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -51,7 +51,6 @@ pub fn iterative_deepening(td: &mut ThreadData, board: &Board, print_uci: bool, 
         prev_score = aspiration_windows(td, &mut pv, prev_score, board, tt);
 
         assert_eq!(0, td.accumulators.top);
-        assert!(!pv.line.is_empty());
         td.best_move = pv.line[0];
 
         if print_uci {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -135,20 +135,20 @@ pub fn parse_time(buff: &[&str]) -> Clock {
     while let Some(uci_opt) = iter.next() {
         match *uci_opt {
             "wtime" => {
-                game_time.time_remaining[Color::White] =
-                    Duration::from_millis(iter.next().unwrap().parse::<u64>().expect("Valid u64"));
+                let raw_time = iter.next().unwrap().parse::<i64>().expect("Valid i64").max(1);
+                game_time.time_remaining[Color::White] = Duration::from_millis(raw_time as u64);
             }
             "btime" => {
-                game_time.time_remaining[Color::Black] =
-                    Duration::from_millis(iter.next().unwrap().parse::<u64>().expect("Valid u64"));
+                let raw_time = iter.next().unwrap().parse::<i64>().expect("Valid i64").max(1);
+                game_time.time_remaining[Color::Black] = Duration::from_millis(raw_time as u64);
             }
             "winc" => {
-                game_time.time_inc[Color::White] =
-                    Duration::from_millis(iter.next().unwrap().parse::<u64>().expect("Valid u64"));
+                let raw_time = iter.next().unwrap().parse::<i64>().expect("Valid i64").max(1);
+                game_time.time_inc[Color::White] = Duration::from_millis(raw_time as u64);
             }
             "binc" => {
-                game_time.time_inc[Color::Black] =
-                    Duration::from_millis(iter.next().unwrap().parse::<u64>().expect("Valid u64"));
+                let raw_time = iter.next().unwrap().parse::<i64>().expect("Valid i64").max(1);
+                game_time.time_inc[Color::Black] = Duration::from_millis(raw_time as u64);
             }
             "movestogo" => game_time.movestogo = iter.next().unwrap().parse::<i32>().expect("Valid i32"),
             _ => return game_time,


### PR DESCRIPTION
bench 5272415
Honestly if I get less than 25 ms of time allotted then I leave it up to the game manager to adjudicate a loss
Elo   | 7.11 +- 5.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 3912 W: 996 L: 916 D: 2000
Penta | [10, 334, 1193, 404, 15]
https://chess.drpowell.org/test/359/