### PR TITLE
Typed moves

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -97,12 +97,10 @@ impl Board {
         false
     }
 
-    pub fn hash_after(&self, m: Move) -> u64 {
+    pub fn hash_after(&self, m: Option<Move>) -> u64 {
         let mut hash = self.zobrist_hash ^ ZOBRIST.turn;
 
-        if m == Move::NULL {
-            return hash;
-        }
+        let Some(m) = m else { return hash };
 
         hash ^= ZOBRIST.piece[m.piece_moving()][m.from()] ^ ZOBRIST.piece[m.piece_moving()][m.to()];
 
@@ -252,10 +250,8 @@ impl Board {
         self.threats = threats;
     }
 
-    pub(crate) fn is_pseudo_legal(&self, m: Move) -> bool {
-        if m == Move::NULL {
-            return false;
-        }
+    pub(crate) fn is_pseudo_legal(&self, m: Option<Move>) -> bool {
+        let Some(m) = m else { return false };
 
         let from = m.from();
         let to = m.to();

--- a/src/eval/accumulator.rs
+++ b/src/eval/accumulator.rs
@@ -14,7 +14,10 @@ use super::{
     Align64, Block, NET,
 };
 use arrayvec::ArrayVec;
-use std::ops::{Index, IndexMut};
+use std::{
+    num::NonZeroU32,
+    ops::{Index, IndexMut},
+};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C, align(64))]
@@ -27,7 +30,12 @@ pub struct Accumulator {
 
 impl Default for Accumulator {
     fn default() -> Self {
-        Self { vals: [NET.feature_bias; 2], correct: [true; 2], m: Move::NULL, capture: Piece::None }
+        Self {
+            vals: [NET.feature_bias; 2],
+            correct: [true; 2],
+            m: Move(NonZeroU32::new(1).unwrap()),
+            capture: Piece::None,
+        }
     }
 }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -6,7 +6,6 @@ pub mod accumulator;
 pub mod network;
 mod simd;
 
-// TODO: perf list and align 64
 type Block = [i16; HIDDEN_SIZE];
 
 pub const INPUT_SIZE: usize = 768;

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -11,22 +11,22 @@ pub mod search;
 
 #[derive(Clone, Copy, Default)]
 pub struct PlyEntry {
-    pub killer_move: Move,
-    pub played_move: Move,
+    pub killer_move: Option<Move>,
+    pub played_move: Option<Move>,
     pub static_eval: i32,
     pub cutoffs: u32,
-    pub singular: Move,
+    pub singular: Option<Move>,
     /// Double extensions
     pub multi_extns: i32,
 }
 
 #[derive(Default)]
 pub struct PV {
-    pub line: ArrayVec<Move, { MAX_SEARCH_DEPTH as usize }>,
+    pub line: ArrayVec<Option<Move>, { MAX_SEARCH_DEPTH as usize }>,
 }
 
 impl PV {
-    fn update(&mut self, m: Move, other: Self) {
+    fn update(&mut self, m: Option<Move>, other: Self) {
         self.line.clear();
         self.line.push(m);
         self.line.extend(other.line);
@@ -39,8 +39,8 @@ pub struct SearchStack {
 }
 
 impl SearchStack {
-    pub fn prev_move(&self, ply: i32) -> Move {
-        self.stack.get(ply as usize).map_or(Move::NULL, |e| e.played_move)
+    pub fn prev_move(&self, ply: i32) -> Option<Move> {
+        self.stack.get(ply as usize).map(|e| e.played_move)?
     }
 }
 

--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -75,7 +75,6 @@ pub(super) fn quiescence<const IS_PV: bool>(
         }
     } else {
         raw_eval = td.accumulators.evaluate(board);
-        // TODO: Store 0 depth here
         tt.store(board.zobrist_hash, Move::NULL, 0, EntryFlag::None, -INFINITY, td.ply, tt_pv, raw_eval);
         estimated_eval = raw_eval;
     };

--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -415,7 +415,7 @@ fn negamax<const IS_PV: bool>(
             r -= history / 9698;
 
             if tt_pv {
-                r -= 1 + i32::from(cut_node);
+                r -= 1 + i32::from(cut_node)
             }
 
             // Calculate a reduction and calculate a reduced depth, ensuring we won't drop to depth
@@ -486,10 +486,7 @@ fn negamax<const IS_PV: bool>(
         if is_quiet {
             // We don't want to store tactical moves in our killer moves, because they are obviously already
             // good.
-            // Also don't store killers that we have already stored
-            if td.stack[td.ply].killer_move != Some(m) {
-                td.stack[td.ply].killer_move = Some(m);
-            }
+            td.stack[td.ply].killer_move = Some(m);
         }
         // Update history tables on a beta cutoff
         td.history.update_histories(m, &quiets_tried, &tacticals_tried, board, depth, &td.stack, td.ply);

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -171,9 +171,9 @@ impl TranspositionTable {
             x.depth.store(0, Ordering::Relaxed);
             x.age_pv_bound.store(0, Ordering::Relaxed);
             x.key.store(0, Ordering::Relaxed);
-            x.search_score.store(0, Ordering::Relaxed);
+            x.search_score.store(-INFINITY as i16, Ordering::Relaxed);
             x.best_move.store(0, Ordering::Relaxed);
-            x.static_eval.store(0, Ordering::Relaxed);
+            x.static_eval.store(-INFINITY as i16, Ordering::Relaxed);
         });
         self.age.0.store(0, Ordering::Relaxed);
     }


### PR DESCRIPTION
Putting moves in a NonZeroU32 allows for Option<Move> to be the same size as a Move (since None can now take up the zeroed out bitpattern). I learned about this data type from viridithas