### PR TITLE
search score >= beta negative extensions

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -307,6 +307,8 @@ fn negamax<const PV: bool>(
 
             if score < ext_beta {
                 1 + i32::from(!PV && score < ext_beta - 18)
+            } else if entry.search_score() >= beta {
+                -2
             } else {
                 0
             }


### PR DESCRIPTION
bench: 6462178

Elo   | 8.50 +- 4.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8590 W: 2195 L: 1985 D: 4410
Penta | [70, 961, 2044, 1129, 91]
https://chess.drpowell.org/test/580/