### PR TITLE
Late move pruning

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -274,6 +274,11 @@ fn negamax<const PV: bool>(
         }
 
         if !is_root && !is_loss(best_score) {
+            let moves_required = (4 + depth * depth) / (3 - i32::from(improving));
+            if moves_searched > moves_required {
+                picker.skip_quiets();
+            }
+
             let margin = if m.is_tactical(board) { -93 } else { -41 } * depth;
             if depth < 12 && !board.see(m, margin) {
                 continue;


### PR DESCRIPTION
Elo   | 64.02 +- 10.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 1180 W: 384 L: 169 D: 627
Penta | [3, 59, 267, 242, 19]
https://chess.drpowell.org/test/599/