### PR TITLE
cutnode negative extensions

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -381,7 +381,7 @@ fn negamax<const PV: bool>(
             } else if entry_score >= beta {
                 -2
             } else if cut_node {
-                -1
+                -2
             } else {
                 0
             }

--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -380,6 +380,8 @@ fn negamax<const PV: bool>(
                 1 + i32::from(!PV && score < ext_beta - 18)
             } else if entry_score >= beta {
                 -2
+            } else if cut_node {
+                -1
             } else {
                 0
             }


### PR DESCRIPTION
Elo   | 1.72 +- 1.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 66042 W: 16113 L: 15787 D: 34142
Penta | [302, 7667, 16758, 7991, 303]
https://chess.drpowell.org/test/628/