### PR TITLE
stricter movepicker see bounds

### DIFF
--- a/src/search/search.rs
+++ b/src/search/search.rs
@@ -330,7 +330,7 @@ fn negamax<const PV: bool>(
     let mut best_score = -Score::INFINITY;
     let mut best_move = Move::NULL;
     let original_alpha = alpha;
-    let mut picker = MovePicker::new(tt_move, td.stack[td.ply].killer, -197, true);
+    let mut picker = MovePicker::new(tt_move, td.stack[td.ply].killer, -65, true);
     while let Some(m) = picker.next(board, td) {
         if Some(m) == excluded_move || !board.is_legal(m) {
             continue;
@@ -567,7 +567,7 @@ fn qsearch<const PV: bool>(
         futility = static_eval + 175;
     }
 
-    let mut picker = MovePicker::new(tt_move, td.stack[td.ply].killer, -197, in_check);
+    let mut picker = MovePicker::new(tt_move, td.stack[td.ply].killer, -75, in_check);
     let mut best_move = Move::NULL;
     let mut moves_searched = 0;
 


### PR DESCRIPTION
Elo   | 2.64 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33312 W: 8260 L: 8007 D: 17045
Penta | [165, 3841, 8401, 4074, 175]
https://chess.drpowell.org/test/636/

bench: 2871783